### PR TITLE
COMP: Fix -Wunused-variable in PBNRR/CreateInverseDeformationField

### DIFF
--- a/PBNRR/PBNRR.cxx
+++ b/PBNRR/PBNRR.cxx
@@ -109,7 +109,6 @@ typename TDeformationField::Pointer CreateInverseDeformationField(typename itk::
 	unsigned int numDofs = 0;
 	itk::fem::Element::DegreeOfFreedomIDType id;
 	typename TDeformationField::PointType global_pt;
-	typename TDeformationField::PointType point;
 
 	// Allocate space for the warped image
 	typename TDeformationField::Pointer pInverseField = TDeformationField::New();


### PR DESCRIPTION
This commit fixes warnings like the following:

```
  /tmp/PBNRR/PBNRR/PBNRR.cxx:112:40: warning: unused variable ‘point’ [-Wunused-variable]
  /tmp/PBNRR/PBNRR/PBNRR.cxx: In instantiation of ‘typename TDeformationField::Pointer {anonymous}::CreateInverseDeformationField(typename slicer_itk::fem::PhysicsBasedNonRigidRegistrationMethod<TFixedImage, TMovingImage, TMaskImage, TMesh, TDeformationField>::Pointer) [with TFixedImage = slicer_itk::Image<float, 3>; TMovingImage = slicer_itk::Image<float, 3>; TMaskImage = slicer_itk::Image<long int, 3>; TMesh = slicer_itk::Mesh<float, 3>; TDeformationField = slicer_itk::Image<slicer_itk::Vector<float, 3>, 3>; typename TDeformationField::Pointer = slicer_itk::SmartPointer<slicer_itk::Image<slicer_itk::Vector<float, 3>, 3> >; typename slicer_itk::fem::PhysicsBasedNonRigidRegistrationMethod<TFixedImage, TMovingImage, TMaskImage, TMesh, TDeformationField>::Pointer = slicer_itk::SmartPointer<slicer_itk::fem::PhysicsBasedNonRigidRegistrationMethod<slicer_itk::Image<float, 3>, slicer_itk::Image<float, 3>, slicer_itk::Image<long int, 3>, slicer_itk::Mesh<float, 3>, slicer_itk::Image<slicer_itk::Vector<float, 3>, 3> > >]’:
  /tmp/PBNRR/PBNRR/PBNRR.cxx:650:167:   required from ‘int {anonymous}::DoIt3(int, char**, const T1&, const T2&, const T3&) [with T1 = float; T2 = float; T3 = long int]’
  /tmp/PBNRR/PBNRR/PBNRR.cxx:707:16:   required from ‘int {anonymous}::DoIt2(int, char**, const T1&, const T2&) [with T1 = float; T2 = float]’
  /tmp/PBNRR/PBNRR/PBNRR.cxx:764:21:   required from ‘int {anonymous}::DoIt(int, char**, const T&) [with T = float]’
  /tmp/PBNRR/PBNRR/PBNRR.cxx:818:51:   required from here
```